### PR TITLE
Add speech recognition and TTS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A lightweight Python project demonstrating multimodal AI interactions with OpenA
 - **Web Interface**: Modern chat UI with drag-and-drop image upload and real-time streaming
 - **Context Management**: Auto-removes old messages when token limits are exceeded
 - **CLI Tool**: Simple terminal interface for quick testing
+- **Speech Support**: Voice recognition via Whisper and text-to-speech playback
 
 ## Installation
 
@@ -37,9 +38,10 @@ Open [http://127.0.0.1:9200/](http://127.0.0.1:9200/) in your browser.
 
 **Features:**
 - Text conversations with GPT models
-- Upload images for analysis (drag & drop or click to upload)  
+- Upload images for analysis (drag & drop or click to upload)
 - Request image generation (e.g., "generate an image of a sunset")
 - Real-time streaming responses
+- Voice input via microphone and spoken replies
 
 ![Web UI](https://github.com/user-attachments/assets/a60655c7-3e67-4d4c-ad8f-d1d797c2576b)
 

--- a/manager.py
+++ b/manager.py
@@ -43,6 +43,37 @@ def request_openai():
     except Exception as e:
         return {'code': 1, 'message': str(e)}, 500
 
+@app.route("/speech_to_text", methods=['POST'])
+def speech_to_text():
+    try:
+        if 'audio' not in request.files:
+            return {'code': 1, 'message': 'Missing audio file'}, 400
+
+        file_obj = request.files['audio']
+        text = dialogue_api_hl.transcribe_audio(file_obj)
+        if text is None:
+            return {'code': 1, 'message': 'transcription failed'}, 500
+        return {'code': 0, 'text': text}
+    except Exception as e:
+        return {'code': 1, 'message': str(e)}, 500
+
+@app.route("/text_to_speech", methods=['POST'])
+def text_to_speech():
+    try:
+        text = request.json.get('text')
+        if not text:
+            return {'code': 1, 'message': 'Missing text'}, 400
+        audio_data = dialogue_api_hl.text_to_speech(text)
+        if audio_data is None:
+            return {'code': 1, 'message': 'tts failed'}, 500
+        return Response(
+            audio_data,
+            mimetype='audio/mpeg',
+            headers={'Content-Disposition': 'attachment; filename="speech.mp3"'}
+        )
+    except Exception as e:
+        return {'code': 1, 'message': str(e)}, 500
+
 @app.route("/request_smart", methods=['POST'])
 def request_smart():
     """

--- a/src/openai_request.py
+++ b/src/openai_request.py
@@ -169,6 +169,39 @@ class OpenAI_Request(object):
         response = requests.post(self.dalle_request_address, headers=self.headers, data=json.dumps(data))
         return response
 
+    def post_whisper_transcription(self, file_obj, model="whisper-1", language=None):
+        """Whisper API request - Speech to Text"""
+        headers = {"Authorization": self.headers.get("Authorization")}
+        files = {"file": (file_obj.filename, file_obj.stream, file_obj.mimetype)}
+        data = {"model": model}
+        if language:
+            data["language"] = language
+
+        response = requests.post(
+            "https://api.openai.com/v1/audio/transcriptions",
+            headers=headers,
+            files=files,
+            data=data,
+        )
+        return response
+
+    def post_tts_request(self, text, voice="alloy", model="tts-1"):
+        """OpenAI TTS API request - Text to Speech"""
+        headers = self.headers.copy()
+        headers["Content-Type"] = "application/json"
+        data = {
+            "model": model,
+            "input": text,
+            "voice": voice,
+            "response_format": "mp3",
+        }
+        response = requests.post(
+            "https://api.openai.com/v1/audio/speech",
+            headers=headers,
+            data=json.dumps(data),
+        )
+        return response
+
 
 if __name__ == '__main__':
     keys = "OpenAI API keys"

--- a/templates/index.html
+++ b/templates/index.html
@@ -314,6 +314,11 @@
                                         <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z" />
                                     </svg>
                                 </button>
+                                <button type="button" class="upload-btn" id="record-btn" title="Record Voice">
+                                    <svg viewBox="0 0 24 24" fill="currentColor">
+                                        <path d="M12 14a3 3 0 0 0 3-3V5a3 3 0 0 0-6 0v6a3 3 0 0 0 3 3m5-3a5 5 0 0 1-10 0H5a7 7 0 0 0 14 0h-2m-5 8v3h4v2H8v-2h4v-3h2Z" />
+                                    </svg>
+                                </button>
                                 <input type="file" id="image-input" accept="image/*" style="display: none;">
                                 <button type="submit" class="send-button">Send</button>
                             </div>
@@ -331,12 +336,16 @@
             const messageInput = document.getElementById('message-input');
             const sendButton = messageForm.querySelector('button');
             const uploadBtn = document.getElementById('upload-btn');
+            const recordBtn = document.getElementById('record-btn');
             const imageInput = document.getElementById('image-input');
             const attachmentPreview = document.getElementById('attachment-preview');
             const previewImage = document.getElementById('preview-image');
             const removeAttachmentBtn = document.getElementById('remove-attachment');
             
             let uploadedImageUrl = null;
+            let mediaRecorder = null;
+            let audioChunks = [];
+            let recording = false;
 
             // 上传按钮点击处理
             uploadBtn.addEventListener('click', () => {
@@ -353,6 +362,40 @@
             // 移除附件处理
             removeAttachmentBtn.addEventListener('click', () => {
                 clearAttachment();
+            });
+
+            recordBtn.addEventListener('click', async () => {
+                if (!recording) {
+                    audioChunks = [];
+                    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+                    mediaRecorder = new MediaRecorder(stream);
+                    mediaRecorder.ondataavailable = e => audioChunks.push(e.data);
+                    mediaRecorder.onstop = async () => {
+                        const blob = new Blob(audioChunks, { type: 'audio/webm' });
+                        const formData = new FormData();
+                        formData.append('audio', blob, 'record.webm');
+                        try {
+                            const res = await fetch('http://127.0.0.1:9200/speech_to_text', {
+                                method: 'POST',
+                                body: formData
+                            });
+                            const data = await res.json();
+                            if (data.code === 0 && data.text) {
+                                messageInput.value = data.text;
+                                messageInput.focus();
+                            }
+                        } catch (e) {
+                            console.error('speech to text failed', e);
+                        }
+                    };
+                    mediaRecorder.start();
+                    recordBtn.classList.add('recording');
+                    recording = true;
+                } else {
+                    mediaRecorder.stop();
+                    recordBtn.classList.remove('recording');
+                    recording = false;
+                }
             });
 
             // 拖拽上传到整个输入区域
@@ -617,6 +660,9 @@
                             if (cursor) {
                                 cursor.remove();
                             }
+                            if (responseText) {
+                                playTTS(responseText);
+                            }
                             break;
                         }
 
@@ -657,6 +703,24 @@
                     if (cursor) {
                         cursor.remove();
                     }
+                }
+            }
+
+            async function playTTS(text) {
+                try {
+                    const resp = await fetch('http://127.0.0.1:9200/text_to_speech', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ text })
+                    });
+                    if (resp.ok) {
+                        const blob = await resp.blob();
+                        const url = URL.createObjectURL(blob);
+                        const audio = new Audio(url);
+                        audio.play();
+                    }
+                } catch (e) {
+                    console.error('TTS failed', e);
                 }
             }
         });

--- a/web_api/dialogue_api.py
+++ b/web_api/dialogue_api.py
@@ -247,6 +247,24 @@ class dialogue_api_handler(object):
                 'error': '!!! The dalle api call is abnormal, please check the backend log'
             }
 
+    def transcribe_audio(self, file_obj, language=None):
+        """Convert speech audio to text using Whisper"""
+        res = self.requestor.post_whisper_transcription(file_obj, language=language)
+        if res.status_code == 200:
+            return res.json().get('text', '')
+        else:
+            print(res.text)
+            return None
+
+    def text_to_speech(self, text, voice="alloy"):
+        """Convert text to speech using OpenAI TTS"""
+        res = self.requestor.post_tts_request(text, voice)
+        if res.status_code == 200:
+            return res.content
+        else:
+            print(res.text)
+            return None
+
     def detect_intent_and_generate(self, user_input, image_url=None):
         """
         Intelligently detect user intent and select appropriate model


### PR DESCRIPTION
## Summary
- integrate Whisper and TTS endpoints in `openai_request`
- expose `/speech_to_text` and `/text_to_speech` API routes
- add helper methods to `dialogue_api_handler`
- enhance web UI with microphone button and TTS playback
- document new speech features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860eab0280c8322b0dff72966b0ed64